### PR TITLE
Enumerate tasks based on uxNumberOfItems for `freertos task` (GCC-346)

### DIFF
--- a/freertos_gdb/common.py
+++ b/freertos_gdb/common.py
@@ -110,7 +110,6 @@ class FreeRtosList():
         self.end_marker = list_['xListEnd']
         self.head = self.end_marker['pxNext']  # ptr to start item
         self._length = list_['uxNumberOfItems']
-        self._index = 0
         self.check_length = check_length
 
     @property
@@ -125,15 +124,16 @@ class FreeRtosList():
 
     def __iter__(self):
         curr_node = self.head
+        index = 0
         while True:
             if curr_node == self.end_marker.address:
                 break
-            if self.check_length and (self._index >= self._length):
+            if self.check_length and index >= self._length:
                 break
             tmp_node = curr_node.dereference()
             data = tmp_node['pvOwner'].cast(self.cast_type)
             yield data
-            self._index += 1
+            index += 1
             curr_node = tmp_node['pxNext']
 
 

--- a/freertos_gdb/common.py
+++ b/freertos_gdb/common.py
@@ -98,11 +98,20 @@ def print_table(table, headers=None):
 
 
 class FreeRtosList():
-    def __init__(self, list_, cast_type_str):
+    """Enumerator for an freertos list (ListItem_t)
+
+    :param list_: List to enumerate
+    :param cast_type_str: Type name to cast list items as
+    :param check_length: If True check uxNumberOfItems to stop iteration. By default check for reaching xListEnd.
+    """
+
+    def __init__(self, list_, cast_type_str, check_length: bool = False):
         self.cast_type = gdb.lookup_type(cast_type_str).pointer()
         self.end_marker = list_['xListEnd']
         self.head = self.end_marker['pxNext']  # ptr to start item
         self._length = list_['uxNumberOfItems']
+        self._index = 0
+        self.check_length = check_length
 
     @property
     def length(self):
@@ -116,10 +125,15 @@ class FreeRtosList():
 
     def __iter__(self):
         curr_node = self.head
-        while curr_node != self.end_marker.address:
+        while True:
+            if curr_node == self.end_marker.address:
+                break
+            if self.check_length and (self._index >= self._length):
+                break
             tmp_node = curr_node.dereference()
             data = tmp_node['pvOwner'].cast(self.cast_type)
             yield data
+            self._index += 1
             curr_node = tmp_node['pxNext']
 
 

--- a/freertos_gdb/task.py
+++ b/freertos_gdb/task.py
@@ -99,7 +99,7 @@ def get_table_row(task_ptr, state, current_tcbs):
 
 def get_table_rows(list_, state, current_tcbs):
     table = []
-    rtos_list = FreeRtosList(list_, 'TCB_t')
+    rtos_list = FreeRtosList(list_, 'TCB_t', check_length=True)
     for _, task_ptr in enumerate(rtos_list):
         if task_ptr == 0:
             print('SEEMS STACK WAS CORRUPTED. TASK POINTER IS NULL.')


### PR DESCRIPTION
For some reason I don't understand enumerating based on checking pvNext == pxListEnd fails for me and I get a lot of corruption reports. Enumerating based on uxNumberOfItems works fine and I can enumerate tasks as expected.