### PR TITLE
Make project compatible with python2.7 (GCC-380)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Python module for user-friendly view freeRTOS-kernel objects in GDB
 
 ## Requirements
 
-GDB must built with python 3.6+ support
+GDB must built with python 2.7+ support
 
 Check your GDB with command:
 
 ```bash
-gdb -q -ex "python print('OK' if sys.version_info.major==3 and sys.version_info.minor>=6 else 'NOT SUPPORTED')" -ex "quit"
+gdb -q -ex "python print('OK' if sys.version_info.major==2 and sys.version_info.minor>=7 else 'NOT SUPPORTED')" -ex "quit"
 ```
 
 ## Install

--- a/freertos_gdb/common.py
+++ b/freertos_gdb/common.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # pylint: disable=import-error
+from __future__ import print_function
 import gdb
 import enum
 
@@ -105,7 +106,7 @@ class FreeRtosList():
     :param check_length: If True check uxNumberOfItems to stop iteration. By default check for reaching xListEnd.
     """
 
-    def __init__(self, list_, cast_type_str, check_length: bool = False):
+    def __init__(self, list_, cast_type_str, check_length = False):
         self.cast_type = gdb.lookup_type(cast_type_str).pointer()
         self.end_marker = list_['xListEnd']
         self.head = self.end_marker['pxNext']  # ptr to start item
@@ -139,4 +140,4 @@ class FreeRtosList():
 
 class FreeRtos(gdb.Command):
     def __init__(self):
-        super().__init__('freertos', gdb.COMMAND_USER, gdb.COMPLETE_NONE, True)
+        super(FreeRtos, self).__init__('freertos', gdb.COMMAND_USER, gdb.COMPLETE_NONE, True)

--- a/freertos_gdb/queue.py
+++ b/freertos_gdb/queue.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # pylint: disable=import-error
+from __future__ import print_function
 import gdb
 from .common import StructProperty, FreeRtosList, print_table
 from .task import TaskProperty
@@ -149,7 +150,7 @@ class Queues:
 def get_task_id_name_str(task):
     task_id = TaskProperty.ID.get_val_as_is(task)
     task_name = TaskProperty.NAME.get_string_val(task)
-    return f'{task_id} {task_name}'
+    return '{task_id} {task_name}'.format(task_id = task_id, task_name = task_name)
 
 
 def show_queues_list(is_semaphore):
@@ -160,7 +161,7 @@ def show_queues_list(is_semaphore):
     try:
         queue_registry = gdb.parse_and_eval('xQueueRegistry')
     except gdb.error as err:
-        print(f'{err}\n{queue_registry_help}')
+        print('{err}\n{queue_registry_help}'.format(err = err, queue_registry_help = queue_registry_help))
         return
     queues = Queues(is_semaphore)
     for idx in range(queue_registry.type.range()[1] + 1):
@@ -174,7 +175,7 @@ class FreeRtosQueue(gdb.Command):
     """
 
     def __init__(self):
-        super().__init__('freertos queue', gdb.COMMAND_USER)
+        super(FreeRtosQueue, self).__init__('freertos queue', gdb.COMMAND_USER)
 
     @staticmethod
     def invoke(_, __):
@@ -186,7 +187,7 @@ class FreeRtosSemaphore(gdb.Command):
     """
 
     def __init__(self):
-        super().__init__('freertos semaphore', gdb.COMMAND_USER)
+        super(FreeRtosSemaphore, self).__init__('freertos semaphore', gdb.COMMAND_USER)
 
     @staticmethod
     def invoke(_, __):

--- a/freertos_gdb/task.py
+++ b/freertos_gdb/task.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # pylint: disable=import-error
+from __future__ import print_function
 import gdb
 import enum
 from .common import StructProperty, FreeRtosList, print_table
@@ -148,7 +149,7 @@ class FreeRtosTask(gdb.Command):
     """
 
     def __init__(self):
-        super().__init__('freertos task', gdb.COMMAND_USER)
+        super(FreeRtosTask, self).__init__('freertos task', gdb.COMMAND_USER)
 
     @staticmethod
     def invoke(_, __):

--- a/freertos_gdb/timer.py
+++ b/freertos_gdb/timer.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # pylint: disable=import-error
+from __future__ import print_function
 import gdb
 from .common import StructProperty, FreeRtosList, print_table
 
@@ -81,7 +82,7 @@ class FreeRtosTimer(gdb.Command):
     """
 
     def __init__(self):
-        super().__init__('freertos timer', gdb.COMMAND_USER)
+        super(FreeRtosTimer, self).__init__('freertos timer', gdb.COMMAND_USER)
 
     @staticmethod
     def invoke(_, __):

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,14 @@
 
 from setuptools import setup
 import sys
+import io
 
-with open('README.md', 'r', encoding='utf-8') as fh:
+with io.open('README.md', 'r', encoding='utf-8') as fh:
     long_description = fh.read()
 
-if sys.version_info[:2] < (3, 6):
+if sys.version_info[:2] < (2, 7):
     sys.exit(
-        'Python < 3.6 is not supported'
+        'Python < 2.7 is not supported'
     )
 
 setup(
@@ -31,6 +32,8 @@ setup(
         'Natural Language :: English',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
@@ -41,5 +44,5 @@ setup(
         'Programming Language :: Python :: Implementation :: CPython',
     ],
     packages=['freertos_gdb'],
-    python_requires='>=3.6',
+    python_requires='>=2.7',
 )


### PR DESCRIPTION
Currently, most prebuilt cross toolchains don't support python3.6+. To make this plugin more popular, it is meaningful to support python2.7.

Please review it. Ping me freely for any suggestions.