### PR TITLE
feat: display CPU affinity of tasks (GCC-397)

### DIFF
--- a/freertos_gdb/task.py
+++ b/freertos_gdb/task.py
@@ -29,12 +29,20 @@ class TaskProperty(StructProperty):
     TCB_NUM = ('Number that increments each time a TCB is created', 'uxTCBNumber', 'get_val')
     NAME = ('', 'pcTaskName', 'get_string_val')
     STATUS = ('', '', 'get_val_as_is')
+    AF = ('CPU affinity', 'xCoreID', 'get_af_val')
     PRI = ('Task priority', 'uxPriority', 'get_val')
     B_PRI = ('Base priority.', 'uxPriority', 'get_val')
     MUTEXES_HELD = ('', 'uxMutexesHeld', 'get_val')
     SS = ('Used stack size.', 'pxEndOfStack', 'get_ss_val')
     SL = ('Free/unused stack size.', 'pxTopOfStack', 'get_sl_val')
     RTC = ('Stores the amount of time the task has spent in the Running state.', 'ulRunTimeCounter', 'get_val')
+
+    def get_af_val(self, task):
+        val = int(task[self.property])
+        if val == 0x7FFFFFFF:
+            # this task has no affinity
+            return '-'
+        return 'CPU' + str(val)
 
     def get_ss_val(self, task):
         return abs(int(task[self.property]) - int(task['pxTopOfStack']))


### PR DESCRIPTION
## Description

This adds a "CPU affinity" column to the task table with `-` used for tasks that don't have any affinity.

## Testing

Example output (with a breakpoint on an event handler callback during startup in QEMU & ESP-IDF v5.4):

<img alt="2025-01-23-15-31-34-screenshot-gdb-freertos-affinity-column" src="https://github.com/user-attachments/assets/8d7a97be-3c3f-49d1-9d30-bc3ca61a2768" width="1753px"/>

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
